### PR TITLE
Remove laravel App dependency to enable other framework usage.

### DIFF
--- a/src/Kodeine/Metable/Metable.php
+++ b/src/Kodeine/Metable/Metable.php
@@ -153,7 +153,7 @@ trait Metable
 
     protected function getModelStub()
     {
-        $model = \App::make('\Kodeine\Metable\MetaData', func_get_args());
+        $model = new \Kodeine\Metable\MetaData(func_get_args());
         $model->setTable($this->metaTable);
 
         return $model;


### PR DESCRIPTION
Hi!
I'm starting using eloquent orm outside of Laravel.
I Found your trait and got an error because of the App class usage. Creating new instance using new instead of App::make works great on my side.

Any particular reason why you're using App::make?
Anyway, here's a pull request if you want to allow others to use your repo outside of Laravel.

Cheers,