### PR TITLE
Fix: Unable to reset a key that is marked for deletion.

### DIFF
--- a/src/Kodeine/Metable/Metable.php
+++ b/src/Kodeine/Metable/Metable.php
@@ -21,6 +21,10 @@ trait Metable
     protected function setMetaString($key, $value)
     {
         if ( $this->metaData->has($key) ) {
+
+            // Make sure deletion marker is not set
+            $this->metaData[$key]->markForDeletion(false);
+
             $this->metaData[$key]->value = $value;
 
             return $this->metaData[$key];


### PR DESCRIPTION
To reproduce error:

    $model->setMeta(‘key’, ‘value’);
    $model->unsetMeta(‘key’);
    $model->setMeta(‘key’, ‘new value’);
    $model->getMeta(‘key’); // Returns null