### PR TITLE
Added meta accessors & mutators.

### DIFF
--- a/src/Kodeine/Metable/Metable.php
+++ b/src/Kodeine/Metable/Metable.php
@@ -323,8 +323,7 @@ trait Metable
             return;
         }
 
-        // if the key has a custom attribute setter and wasn't 
-        // a model attribute we'll execute it here
+        // if the key has a mutator execute it
         $mutator = camel_case('set_' . $key . '_meta');
 
         if ( method_exists($this, $mutator) ) {

--- a/src/Kodeine/Metable/Metable.php
+++ b/src/Kodeine/Metable/Metable.php
@@ -290,7 +290,7 @@ trait Metable
         // Check for meta accessor
         $accessor = camel_case('get_' . $attr . '_meta');
 
-        if ( method_exists($this, $accessor)) {
+        if ( method_exists($this, $accessor) ) {
             return $this->{$accessor}();
         }
 

--- a/src/Kodeine/Metable/Metable.php
+++ b/src/Kodeine/Metable/Metable.php
@@ -287,6 +287,14 @@ trait Metable
 
     public function __get($attr)
     {
+        // Check for meta accessor
+        $accessor = camel_case('get_' . $attr . '_meta');
+
+        if ( method_exists($this, $accessor)) {
+            return $this->{$accessor}();
+        }
+
+        // Check for legacy getter
         $getter = 'get' . ucfirst($attr);
 
         // leave model relation methods for parent::
@@ -312,6 +320,15 @@ trait Metable
         if ( array_key_exists($key, parent::getAttributes()) ) {
             parent::setAttribute($key, $value);
 
+            return;
+        }
+
+        // if the key has a custom attribute setter and wasn't 
+        // a model attribute we'll execute it here
+        $mutator = camel_case('set_' . $key . '_meta');
+
+        if ( method_exists($this, $mutator) ) {
+            $this->{$mutator}($value);
             return;
         }
 


### PR DESCRIPTION
Hey,

I've added meta accessors and mutators in the form of `getKeyNameMeta()` and `setKeyNameMeta($value)`. I've left the old getter functionality in there for compatibilities sake but figured for consistency going forward the named version would make more sense?

Cheers, Oliver