### PR TITLE
Fix unsupported if shorthand PHP < 7.0 (5.*)

### DIFF
--- a/src/Kodeine/Metable/Metable.php
+++ b/src/Kodeine/Metable/Metable.php
@@ -15,7 +15,7 @@ trait Metable
      */
     public function scopeMeta($query, $alias = null)
     {
-        $alias = $alias ?? $this->getMetaTable();
+        $alias = (empty($alias)) ? $this->getMetaTable() : $alias;
         return $query->join($this->getMetaTable() . ' AS ' . $alias, $this->getQualifiedKeyName(), '=', $alias . '.' . $this->getMetaKeyName())->select($this->getTable() . '.*');
     }
 


### PR DESCRIPTION
Unsuported if shorthand for PHP < 7.0 based from [this problem](https://github.com/kodeine/laravel-meta/commit/58398600c0e82a6da16a5db1daa07f9807a577ee#commitcomment-31185393).