### PR TITLE
Improves large dataset performances

### DIFF
--- a/src/Kodeine/Metable/Metable.php
+++ b/src/Kodeine/Metable/Metable.php
@@ -8,7 +8,10 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 trait Metable
 {
-
+    
+    // Static property registration sigleton for save observation and slow large set hotfix
+    public static $_isObserverRegistered;
+    
     /**
      * Meta scope for easier join
      * -------------------------
@@ -174,9 +177,12 @@ trait Metable
      */
     protected function setObserver()
     {
-        $this->saved(function ($model) {
-            $model->saveMeta();
-        });
+        if(!isset(self::$_isObserverRegistered)) {
+            $this->saved(function ($model) {
+                $model->saveMeta();
+            });
+            self::$_isObserverRegistered = true;
+        }
     }
 
     protected function getModelStub()


### PR DESCRIPTION
Hi,

I am using this package on large datasets and performances are horrible on some crons. I figured with blackfire that the package is observing the model `save` event for each instance whereas the `save` event should be listened statically on the model class.

It result to a n+1 saving problem like this :

* Saving model 1
* Saving model 2
* Saving model 2
* Saving model 3
* Saving model 3
* Saving model 3
etc ...

This hotfix is correcting this problem and improve my large dataset work from 3 hours to 5 minutes. This is "dirty" but it works. I recommend you to change the `save` observation by using the boot method just one time instead of each call : https://laravel.com/docs/5.7/events#manually-registering-events