### PR TITLE
Primary key column name to ignore

### DIFF
--- a/src/Kodeine/Metable/Metable.php
+++ b/src/Kodeine/Metable/Metable.php
@@ -100,6 +100,10 @@ trait Metable
         if (is_string($key) && preg_match('/[,|]/is', $key, $m)) {
             $key = preg_split('/ ?[,|] ?/', $key);
         }
+        
+        if($key === $this->getKeyName()) {
+            return;
+        }
 
         $getMeta = 'getMeta'.ucfirst(strtolower(gettype($key)));
 


### PR DESCRIPTION
There is problem when id name is altered in mysql query, then 'id' si searched and not found, this will fix calls to primary key meta.