### PR TITLE
Allow to overwrite MetaData class

### DIFF
--- a/src/Kodeine/Metable/Metable.php
+++ b/src/Kodeine/Metable/Metable.php
@@ -184,7 +184,7 @@ trait Metable
     {
         // get new meta model instance
         $classname = $this->getMetaClass();
-        $model = $classname;
+        $model = new $classname;
         $model->setTable($this->metaTable);
 
         // model fill with attributes.

--- a/src/Kodeine/Metable/Metable.php
+++ b/src/Kodeine/Metable/Metable.php
@@ -271,7 +271,7 @@ trait Metable
      */
     protected function getMetaClass()
     {
-        return isset($this->metaClass) ? $this->metaClass : Kodeine\Metable\MetaData::class;
+        return isset($this->metaClass) ? $this->metaClass : MetaData::class;
     }
 
     /**

--- a/src/Kodeine/Metable/Metable.php
+++ b/src/Kodeine/Metable/Metable.php
@@ -265,7 +265,7 @@ trait Metable
     }
 
     /**
-     * Return the table name.
+     * Return the model class name.
      *
      * @return string
      */

--- a/src/Kodeine/Metable/Metable.php
+++ b/src/Kodeine/Metable/Metable.php
@@ -382,7 +382,7 @@ trait Metable
         }
 
         // if model table has the column named to the key
-        if (\Schema::hasColumn($this->getTable(), $key)) {
+        if (\Schema::connection($this->connection)->hasColumn($this->getTable(), $key)) {
             parent::setAttribute($key, $value);
 
             return;

--- a/src/Kodeine/Metable/Metable.php
+++ b/src/Kodeine/Metable/Metable.php
@@ -150,7 +150,8 @@ trait Metable
      */
     public function metas()
     {
-        $model = new \Kodeine\Metable\MetaData();
+        $classname = $this->getMetaClass();
+        $model = new $classname;
         $model->setTable($this->getMetaTable());
 
         return new HasMany($model->newQuery(), $this, $this->getMetaKeyName(), $this->getKeyName());
@@ -182,7 +183,8 @@ trait Metable
     protected function getModelStub()
     {
         // get new meta model instance
-        $model = new \Kodeine\Metable\MetaData();
+        $classname = $this->getMetaClass();
+        $model = $classname;
         $model->setTable($this->metaTable);
 
         // model fill with attributes.
@@ -255,11 +257,21 @@ trait Metable
     /**
      * Return the table name.
      *
-     * @return null
+     * @return string
      */
     protected function getMetaTable()
     {
         return isset($this->metaTable) ? $this->metaTable : $this->getTable().'_meta';
+    }
+
+    /**
+     * Return the table name.
+     *
+     * @return string
+     */
+    protected function getMetaClass()
+    {
+        return isset($this->metaClass) ? $this->metaClass : Kodeine\Metable\MetaData::class;
     }
 
     /**


### PR DESCRIPTION
In some situation we need to implement other configurations or methods to metadata models, like using a different connection, or additional relationships.

This changes allow us to make this by overwriting the `getMetaClass()` method where we want to.