### PR TITLE
Adding setAttributes() method to Metable Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,18 @@ $post->setMeta([
 $post->save();
 ```
 
+Or `set multiple metas and columns` at once:
+
+```php
+...
+$post->setAttributes([
+    'name' => 'hello world'; // model attribute
+    'content' => 'Some content here',
+    'views' => 1,
+]);
+$post->save();
+```
+
 > **Note:** If a piece of content already has a meta the existing value will be updated.
 
 #### Unsetting Content Meta

--- a/src/Kodeine/Metable/Metable.php
+++ b/src/Kodeine/Metable/Metable.php
@@ -298,6 +298,19 @@ trait Metable
         return $this->getMeta($key);
     }
 
+    /**
+     * Set attributes for the model
+     *
+     * @param array $attributes
+     *
+     * @return void
+     */
+    public function setAttributes(array $attributes) {
+        foreach ($attributes as $key => $value) {
+            $this->$key = $value;
+        }
+    }
+
     public function __unset($key)
     {
         // unset attributes and relations


### PR DESCRIPTION
We can easily set all attributes (even from table and meta), which is harder to override with `Model::fill()`).