### PR TITLE
Update usages of string helpers removed in Laravel 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "~5.0|~5.1"
+        "illuminate/support": "~6.0"
     },
     "autoload": {
         "classmap": [

--- a/src/Kodeine/Metable/Metable.php
+++ b/src/Kodeine/Metable/Metable.php
@@ -4,6 +4,7 @@ namespace Kodeine\Metable;
 
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Collection as BaseCollection;
+use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 trait Metable
@@ -314,7 +315,7 @@ trait Metable
     public function __get($attr)
     {
         // Check for meta accessor
-        $accessor = camel_case('get_'.$attr.'_meta');
+        $accessor = Str::camel('get_'.$attr.'_meta');
 
         if (method_exists($this, $accessor)) {
             return $this->{$accessor}();
@@ -336,7 +337,7 @@ trait Metable
     public function __set($key, $value)
     {
         // ignore the trait properties being set.
-        if (starts_with($key, 'meta') || $key == 'query') {
+        if (Str::startsWith($key, 'meta') || $key == 'query') {
             $this->$key = $value;
 
             return;
@@ -350,7 +351,7 @@ trait Metable
         }
 
         // if the key has a mutator execute it
-        $mutator = camel_case('set_'.$key.'_meta');
+        $mutator = Str::camel('set_'.$key.'_meta');
 
         if (method_exists($this, $mutator)) {
             $this->{$mutator}($value);
@@ -385,7 +386,7 @@ trait Metable
     public function __isset($key)
     {
         // trait properties.
-        if (starts_with($key, 'meta') || $key == 'query') {
+        if (Str::startsWith($key, 'meta') || $key == 'query') {
             return isset($this->{$key});
         }
 


### PR DESCRIPTION
String helpers have been [removed from the framework](https://laravel.com/docs/6.x/upgrade#helpers) in Laravel 6.0. This PR updates usages of the removed string helpers to utilize the `Str` class instead.