### PR TITLE
Check model relation on __set method

### DIFF
--- a/src/Kodeine/Metable/Metable.php
+++ b/src/Kodeine/Metable/Metable.php
@@ -3,6 +3,7 @@
 namespace Kodeine\Metable;
 
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -387,7 +388,7 @@ trait Metable
         }
 
         // if key is a model attribute, set as is
-        if (array_key_exists($key, parent::getAttributes())) {
+        if (array_key_exists($key, parent::getAttributes()) || $this->{$key}() instanceof Relation) {
             parent::setAttribute($key, $value);
 
             return;

--- a/src/Kodeine/Metable/Metable.php
+++ b/src/Kodeine/Metable/Metable.php
@@ -388,7 +388,7 @@ trait Metable
         }
 
         // if key is a model attribute, set as is
-        if (array_key_exists($key, parent::getAttributes()) || $this->{$key}() instanceof Relation) {
+        if (array_key_exists($key, parent::getAttributes())) {
             parent::setAttribute($key, $value);
 
             return;

--- a/src/Kodeine/Metable/Metable.php
+++ b/src/Kodeine/Metable/Metable.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 trait Metable
 {
-    
+
     // Static property registration sigleton for save observation and slow large set hotfix
     public static $_isObserverRegistered;
 
@@ -393,6 +393,15 @@ trait Metable
 
             return;
         }
+
+        // if key is a relation, set as is
+        try {
+            if ($this->{$key}() instanceof Relation) {
+                parent::setAttribute($key, $value);
+
+                return;
+            }
+        } catch (\BadMethodCallException $ex) {}
 
         // If there is a default value, remove the meta row instead - future returns of
         // this value will be handled via the default logic in the accessor


### PR DESCRIPTION
What this PR fixes. When I was trying to use this package and save a `BelongsTo` relation it was being saved to the meta table instead of the model's table.
This is probably because I am using OctoberCMS which is based on Laravel, but defines relations slightly differently (as attributes instead of methods but are still accessed and written to the same way).

So, this commit will check to see if that method returns a relation and if so, will save it to the model like normal.

I haven't actually tested this change in Laravel, but I assume this should still work. Also, if you don't want to merge this change I'd also understand I would appreciate it though so I wouldn't need to maintain a separate fork.