### PR TITLE
cache hasColumn to prevent executing duplicate queries

### DIFF
--- a/src/Kodeine/Metable/Metable.php
+++ b/src/Kodeine/Metable/Metable.php
@@ -12,6 +12,7 @@ trait Metable
     
     // Static property registration sigleton for save observation and slow large set hotfix
     public static $_isObserverRegistered;
+    public static $_columnNames;
 
     /**
      * Meta scope for easier join
@@ -341,6 +342,18 @@ trait Metable
             $this->$key = $value;
         }
     }
+    
+    /**
+     * Determine if model table has a given column.
+     * 
+     * @param  [string]  $column
+     * 
+     * @return boolean
+     */
+    public function hasColumn($column) {
+        if(empty(self::$_columnNames)) self::$_columnNames = array_map('strtolower',\Schema::connection($this->connection)->getColumnListing($this->getTable()));
+        return in_array(strtolower($column), self::$_columnNames);
+    }
 
     public function __unset($key)
     {
@@ -426,7 +439,7 @@ trait Metable
         }
 
         // if model table has the column named to the key
-        if (\Schema::connection($this->connection)->hasColumn($this->getTable(), $key)) {
+        if ($this->hasColumn($key)) {
             parent::setAttribute($key, $value);
 
             return;


### PR DESCRIPTION
Hi
I was reviewing executed queries in telescope and noticed there are duplicate queries like this:

> select column_name as `column_name` from information_schema.columns where table_schema = 'db_name' and table_name = 'table_name' 

so I traced the query and saw this:
https://github.com/kodeine/laravel-meta/blob/052098ba5934729b717adb0ce941ad38f2889318/src/Kodeine/Metable/Metable.php#L429
which is called every time I try to set new attribute to the model and executes that query every time.
so this PR will cache the query result and prevents executing same query multiple times.