### PR TITLE
Fixing a bug with the model's connection

### DIFF
--- a/src/Kodeine/Metable/Metable.php
+++ b/src/Kodeine/Metable/Metable.php
@@ -351,7 +351,7 @@ trait Metable
      * @return boolean
      */
     public function hasColumn($column) {
-        if(empty(self::$_columnNames)) self::$_columnNames = array_map('strtolower',\Schema::connection($this->connection)->getColumnListing($this->getTable()));
+        if(empty(self::$_columnNames)) self::$_columnNames = array_map('strtolower',\Schema::connection($this->getConnectionName())->getColumnListing($this->getTable()));
         return in_array(strtolower($column), self::$_columnNames);
     }
 


### PR DESCRIPTION
`$this->connection` doesn't respect changes that may have occurred to the model's database connection.  Multi-tenancy packages for example commonly change the model's connection.