### PR TITLE
🐛 Ensure getModelStub and saveMeta work when metaTable isn't set

### DIFF
--- a/src/Kodeine/Metable/Metable.php
+++ b/src/Kodeine/Metable/Metable.php
@@ -213,7 +213,7 @@ trait Metable
         // get new meta model instance
         $classname = $this->getMetaClass();
         $model = new $classname;
-        $model->setTable($this->metaTable);
+        $model->setTable($this->getMetaTable());
 
         // model fill with attributes.
         if (func_num_args() > 0) {
@@ -226,7 +226,7 @@ trait Metable
     protected function saveMeta()
     {
         foreach ($this->metaData as $meta) {
-            $meta->setTable($this->metaTable);
+            $meta->setTable($this->getMetaTable());
 
             if ($meta->isMarkedForDeletion()) {
                 $meta->delete();


### PR DESCRIPTION
I'm not aware of any specific bug that that this was causing, but I noticed that `$this->metaTable` was used twice in the `Metable` trait. Since, `metaTable` not not always be set, `$this->getMetaTable()` should always be used.