### PR TITLE
[2.0.1] Improved getMetaArray method by removing linear search from getMetaArray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## v2.0.1
+
+### Changes
+
+* Improved `getMetaArray` method by removing linear search from `getMetaArray`
+
 ## v2.0.0
 
 ### Added

--- a/src/Kodeine/Metable/Metable.php
+++ b/src/Kodeine/Metable/Metable.php
@@ -96,9 +96,9 @@ trait Metable
 		if ( is_string( $key ) && preg_match( '/[,|]/is', $key ) ) {
 			$key = preg_split( '/ ?[,|] ?/', $key );
 		}
-		$setMeta = 'hasMeta' . ucfirst( gettype( $key ) );
+		$hasMeta = 'hasMeta' . ucfirst( gettype( $key ) );
 		
-		return $this->$setMeta( $key );
+		return $this->$hasMeta( $key );
 	}
 	
 	protected function hasMetaString($key): bool {

--- a/src/Kodeine/Metable/Metable.php
+++ b/src/Kodeine/Metable/Metable.php
@@ -183,6 +183,7 @@ trait Metable
 	}
 	
 	protected function getMetaString($key, $default = null) {
+		$key = strtolower( $key );
 		$meta = $this->getMetaData()->get( $key );
 		
 		if ( is_null( $meta ) || $meta->isMarkedForDeletion() ) {

--- a/src/Kodeine/Metable/Metable.php
+++ b/src/Kodeine/Metable/Metable.php
@@ -195,16 +195,18 @@ trait Metable
 	
 	protected function getMetaArray($keys, $default = null): BaseCollection {
 		$collection = new BaseCollection();
-		$flipped = array_flip( $keys );
-		foreach ($this->getMetaData() as $meta) {
-			if ( ! $meta->isMarkedForDeletion() && isset( $flipped[$meta->key] ) ) {
-				unset( $flipped[$meta->key] );
-				$collection->put( $meta->key, $meta->value );
+		
+		foreach ($keys as $key) {
+			$key = strtolower( $key );
+			if ( $this->hasMeta( $key ) ) {
+				$meta = $this->getMetaData()[$key];
+				if ( ! $meta->isMarkedForDeletion() ) {
+					$collection->put( $key, $meta->value );
+					continue;
+				}
 			}
-		}
-		// If there are any keys left in $flipped, it means they are not set. so fill them with default values.
-		// Default values set in defaultMetaValues property take precedence over default values passed to this method
-		foreach ($flipped as $key => $value) {
+			// Key does not exist, so it's value will be the default value
+			// Default values set in defaultMetaValues property take precedence over default value passed to this method
 			$defaultValue = $this->getDefaultMetaValue( $key );
 			if ( is_null( $defaultValue ) ) {
 				if ( is_array( $default ) ) {


### PR DESCRIPTION
`getMetaArray` was performing linear search on metas. Metas already indexed by their keys so I removed linear search and replaced it with loop on requested keys and checking if that key exists on metas.
And some minor changes.