### PR TITLE
[2.2.0] Added createdWithMetas, updatedWithMetas, savedWithMetas events.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release Notes
 
+## v2.2.0
+
+### Added
+
+* Added `createdWithMetas`, `updatedWithMetas`, `savedWithMetas` events.
+
+## v2.1.1
+
+### Added
+
+* Added Laravel 10.x Compatibility.
+
 ## v2.1.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -430,6 +430,12 @@ After that, you can listen for events the [same way](https://laravel.com/docs/ma
 
 > If you `return false;` in listener of any event ending with `ing`, that operation will be aborted.
 
+### Additional events
+
+There are some additional events that extend existing laravel events. These events don't need `HasMetaEvents` trait and like default laravel events, the event listeners should expect one parameter.
+Event names: `createdWithMetas`, `updatedWithMetas`, `savedWithMetas`. These events fire exactly like default laravel events except that they are only fired after all metas saved to database.
+For example, you may need to access metas inside a queue job after model created. But because metas have not been saved to database yet (metas will be saved to database in `saved` event and this event has not been fired yet), job can't access them. by using `createdWithMetas` event instead of `created` event, the problem will be solved.
+
 There are 3 ways to listen for events:
 
 #### 1. By Defining `$dispatchesEvents` Property

--- a/src/Kodeine/Metable/Metable.php
+++ b/src/Kodeine/Metable/Metable.php
@@ -16,6 +16,7 @@ trait Metable
 	protected $__metaData = null;
 	protected $__wasCreatedEventFired = false;
 	protected $__wasUpdatedEventFired = false;
+	protected $__wasSavedEventFired = false;
 	
 	/**
 	 * whereMeta scope for easier join
@@ -351,6 +352,11 @@ trait Metable
 			$this->__wasUpdatedEventFired = false;
 			$this->fireModelEvent( 'updatedWithMetas', false );
 		}
+		
+		if ( $this->__wasSavedEventFired ) {
+			$this->__wasSavedEventFired = false;
+			$this->fireModelEvent( 'savedWithMetas', false );
+		}
 	}
 	
 	protected function fireMetaEvent($event, $metaName, bool $halt = true) {
@@ -539,6 +545,7 @@ trait Metable
 	
 	public static function bootMetable() {
 		static::saved( function ($model) {
+			$model->__wasSavedEventFired = true;
 			$model->saveMeta();
 		} );
 		
@@ -549,11 +556,13 @@ trait Metable
 		static::updated( function ($model) {
 			$model->__wasUpdatedEventFired = true;
 		} );
+	}
 	
 	protected function initializeMetable() {
 		$this->observables = array_merge( $this->observables, [
 			'createdWithMetas',
 			'updatedWithMetas',
+			'savedWithMetas',
 		] );
 		$this->observables = array_unique( $this->observables );
 	}
@@ -565,6 +574,9 @@ trait Metable
 	public static function updatedWithMetas($callback) {
 		static::registerModelEvent( 'updatedWithMetas', $callback );
 	}
+	
+	public static function savedWithMetas($callback) {
+		static::registerModelEvent( 'savedWithMetas', $callback );
 	}
 	
 	public function __unset($key) {

--- a/src/Kodeine/Metable/Metable.php
+++ b/src/Kodeine/Metable/Metable.php
@@ -15,6 +15,7 @@ trait Metable
 	
 	protected $__metaData = null;
 	protected $__wasCreatedEventFired = false;
+	protected $__wasUpdatedEventFired = false;
 	
 	/**
 	 * whereMeta scope for easier join
@@ -345,6 +346,11 @@ trait Metable
 			$this->__wasCreatedEventFired = false;
 			$this->fireModelEvent( 'createdWithMetas', false );
 		}
+		
+		if ( $this->__wasUpdatedEventFired ) {
+			$this->__wasUpdatedEventFired = false;
+			$this->fireModelEvent( 'updatedWithMetas', false );
+		}
 	}
 	
 	protected function fireMetaEvent($event, $metaName, bool $halt = true) {
@@ -539,16 +545,25 @@ trait Metable
 		static::created( function ($model) {
 			$model->__wasCreatedEventFired = true;
 		} );
+		
+		static::updated( function ($model) {
+			$model->__wasUpdatedEventFired = true;
+		} );
 	
 	protected function initializeMetable() {
 		$this->observables = array_merge( $this->observables, [
 			'createdWithMetas',
+			'updatedWithMetas',
 		] );
 		$this->observables = array_unique( $this->observables );
 	}
 	
 	public static function createdWithMetas($callback) {
 		static::registerModelEvent( 'createdWithMetas', $callback );
+	}
+	
+	public static function updatedWithMetas($callback) {
+		static::registerModelEvent( 'updatedWithMetas', $callback );
 	}
 	}
 	

--- a/src/Kodeine/Metable/Metable.php
+++ b/src/Kodeine/Metable/Metable.php
@@ -14,6 +14,7 @@ trait Metable
 {
 	
 	protected $__metaData = null;
+	protected $__wasCreatedEventFired = false;
 	
 	/**
 	 * whereMeta scope for easier join
@@ -339,6 +340,11 @@ trait Metable
 				}
 			}
 		}
+		
+		if ( $this->__wasCreatedEventFired ) {
+			$this->__wasCreatedEventFired = false;
+			$this->fireModelEvent( 'createdWithMetas', false );
+		}
 	}
 	
 	protected function fireMetaEvent($event, $metaName, bool $halt = true) {
@@ -529,6 +535,21 @@ trait Metable
 		static::saved( function ($model) {
 			$model->saveMeta();
 		} );
+		
+		static::created( function ($model) {
+			$model->__wasCreatedEventFired = true;
+		} );
+	
+	protected function initializeMetable() {
+		$this->observables = array_merge( $this->observables, [
+			'createdWithMetas',
+		] );
+		$this->observables = array_unique( $this->observables );
+	}
+	
+	public static function createdWithMetas($callback) {
+		static::registerModelEvent( 'createdWithMetas', $callback );
+	}
 	}
 	
 	public function __unset($key) {

--- a/tests/Events/BaseEventTest.php
+++ b/tests/Events/BaseEventTest.php
@@ -12,7 +12,7 @@ class BaseEventTest
 	public $model;
 	public $meta;
 	
-	public function __construct(EventTest $model, $meta) {
+	public function __construct(EventTest $model, $meta = null) {
 		$this->model = $model;
 		$this->meta = $meta;
 	}

--- a/tests/Events/CreatedWithMetasTestEvent.php
+++ b/tests/Events/CreatedWithMetasTestEvent.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Kodeine\Metable\Tests\Events;
+
+
+class CreatedWithMetasTestEvent extends BaseEventTest
+{
+	
+}

--- a/tests/Events/SavedWithMetasTestEvent.php
+++ b/tests/Events/SavedWithMetasTestEvent.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Kodeine\Metable\Tests\Events;
+
+class SavedWithMetasTestEvent extends BaseEventTest
+{
+	
+}

--- a/tests/Events/UpdatedWithMetasTestEvent.php
+++ b/tests/Events/UpdatedWithMetasTestEvent.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Kodeine\Metable\Tests\Events;
+
+class UpdatedWithMetasTestEvent extends BaseEventTest
+{
+	
+}

--- a/tests/Listeners/HandleCreatedWithMetasTestEvent.php
+++ b/tests/Listeners/HandleCreatedWithMetasTestEvent.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Kodeine\Metable\Tests\Listeners;
+
+class HandleCreatedWithMetasTestEvent extends BaseListenerTest
+{
+	
+}

--- a/tests/Listeners/HandleSavedWithMetasTestEvent.php
+++ b/tests/Listeners/HandleSavedWithMetasTestEvent.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Kodeine\Metable\Tests\Listeners;
+
+class HandleSavedWithMetasTestEvent extends BaseListenerTest
+{
+	
+}

--- a/tests/Listeners/HandleUpdatedWithMetasTestEvent.php
+++ b/tests/Listeners/HandleUpdatedWithMetasTestEvent.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Kodeine\Metable\Tests\Listeners;
+
+class HandleUpdatedWithMetasTestEvent extends BaseListenerTest
+{
+	
+}

--- a/tests/Models/EventTest.php
+++ b/tests/Models/EventTest.php
@@ -15,6 +15,7 @@ use Kodeine\Metable\Tests\Events\MetaDeletedTestEvent;
 use Kodeine\Metable\Tests\Events\MetaUpdatingTestEvent;
 use Kodeine\Metable\Tests\Events\MetaDeletingTestEvent;
 use Kodeine\Metable\Tests\Events\MetaCreatingTestEvent;
+use Kodeine\Metable\Tests\Events\UpdatedWithMetasTestEvent;
 
 class EventTest extends Model
 {
@@ -37,6 +38,7 @@ class EventTest extends Model
 		'metaDeleting' => MetaDeletingTestEvent::class,
 		'metaDeleted' => MetaDeletedTestEvent::class,
 		'createdWithMetas' => CreatedWithMetasTestEvent::class,
+		'updatedWithMetas' => UpdatedWithMetasTestEvent::class,
 	];
 	
 	public static function boot() {
@@ -87,6 +89,10 @@ class EventTest extends Model
 		
 		static::createdWithMetas( function (EventTest $model) use ($listener) {
 			return $listener( $model, null, 'createdWithMetas' );
+		} );
+		
+		static::updatedWithMetas( function (EventTest $model) use ($listener) {
+			return $listener( $model, null, 'updatedWithMetas' );
 		} );
 	}
 }

--- a/tests/Models/EventTest.php
+++ b/tests/Models/EventTest.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 use Kodeine\Metable\Tests\Events\MetaSavedTestEvent;
 use Kodeine\Metable\Tests\Events\MetaSavingTestEvent;
 use Kodeine\Metable\Tests\Events\MetaCreatedTestEvent;
+use Kodeine\Metable\Tests\Events\SavedWithMetasTestEvent;
 use Kodeine\Metable\Tests\Events\CreatedWithMetasTestEvent;
 use Kodeine\Metable\Tests\Events\MetaUpdatedTestEvent;
 use Kodeine\Metable\Tests\Events\MetaDeletedTestEvent;
@@ -39,6 +40,7 @@ class EventTest extends Model
 		'metaDeleted' => MetaDeletedTestEvent::class,
 		'createdWithMetas' => CreatedWithMetasTestEvent::class,
 		'updatedWithMetas' => UpdatedWithMetasTestEvent::class,
+		'savedWithMetas' => SavedWithMetasTestEvent::class,
 	];
 	
 	public static function boot() {
@@ -93,6 +95,10 @@ class EventTest extends Model
 		
 		static::updatedWithMetas( function (EventTest $model) use ($listener) {
 			return $listener( $model, null, 'updatedWithMetas' );
+		} );
+		
+		static::savedWithMetas( function (EventTest $model) use ($listener) {
+			return $listener( $model, null, 'savedWithMetas' );
 		} );
 	}
 }

--- a/tests/Models/EventTest.php
+++ b/tests/Models/EventTest.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 use Kodeine\Metable\Tests\Events\MetaSavedTestEvent;
 use Kodeine\Metable\Tests\Events\MetaSavingTestEvent;
 use Kodeine\Metable\Tests\Events\MetaCreatedTestEvent;
+use Kodeine\Metable\Tests\Events\CreatedWithMetasTestEvent;
 use Kodeine\Metable\Tests\Events\MetaUpdatedTestEvent;
 use Kodeine\Metable\Tests\Events\MetaDeletedTestEvent;
 use Kodeine\Metable\Tests\Events\MetaUpdatingTestEvent;
@@ -35,6 +36,7 @@ class EventTest extends Model
 		'metaUpdated' => MetaUpdatedTestEvent::class,
 		'metaDeleting' => MetaDeletingTestEvent::class,
 		'metaDeleted' => MetaDeletedTestEvent::class,
+		'createdWithMetas' => CreatedWithMetasTestEvent::class,
 	];
 	
 	public static function boot() {
@@ -81,6 +83,10 @@ class EventTest extends Model
 		
 		static::metaDeleted( function (EventTest $model, $meta) use ($listener) {
 			return $listener( $model, $meta, 'metaDeleted' );
+		} );
+		
+		static::createdWithMetas( function (EventTest $model) use ($listener) {
+			return $listener( $model, null, 'createdWithMetas' );
 		} );
 	}
 }

--- a/tests/Observers/EventObserver.php
+++ b/tests/Observers/EventObserver.php
@@ -38,6 +38,10 @@ class EventObserver
 		return $this->genericObserver( $model, $meta, __FUNCTION__ );
 	}
 	
+	public function createdWithMetas(EventTest $model) {
+		return $this->genericObserver( $model, null, __FUNCTION__ );
+	}
+	
 	protected function genericObserver(EventTest $model, $meta, $eventName) {
 		if ( ! isset( $model->observersChanges[$eventName] ) ) {
 			$model->observersChanges[$eventName] = [];

--- a/tests/Observers/EventObserver.php
+++ b/tests/Observers/EventObserver.php
@@ -46,6 +46,10 @@ class EventObserver
 		return $this->genericObserver( $model, null, __FUNCTION__ );
 	}
 	
+	public function savedWithMetas(EventTest $model) {
+		return $this->genericObserver( $model, null, __FUNCTION__ );
+	}
+	
 	protected function genericObserver(EventTest $model, $meta, $eventName) {
 		if ( ! isset( $model->observersChanges[$eventName] ) ) {
 			$model->observersChanges[$eventName] = [];

--- a/tests/Observers/EventObserver.php
+++ b/tests/Observers/EventObserver.php
@@ -42,6 +42,10 @@ class EventObserver
 		return $this->genericObserver( $model, null, __FUNCTION__ );
 	}
 	
+	public function updatedWithMetas(EventTest $model) {
+		return $this->genericObserver( $model, null, __FUNCTION__ );
+	}
+	
 	protected function genericObserver(EventTest $model, $meta, $eventName) {
 		if ( ! isset( $model->observersChanges[$eventName] ) ) {
 			$model->observersChanges[$eventName] = [];


### PR DESCRIPTION
Hi @kodeine 
This PR Adds createdWithMetas, updatedWithMetas, savedWithMetas events.
The reason for adding these events is #102.
The events will fire after all metas saved to database.
However I'm not sure I picked the right name for these events. If you have a better name let me know or jsut merge it if you think it's fine.